### PR TITLE
implemented #22 As a player I want to be put in a queue when waiting for my next game to play.

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -46,7 +46,7 @@ class Player:
     def full():
       print('Server is full :(')
       self.sio.disconnect()
-    
+
     @self.sio.on('disconnect')
     def disconnect():
       print('Disconnected')
@@ -54,6 +54,10 @@ class Player:
     @self.sio.on('*')
     def catch_all():
       print('Error')
+
+    @self.sio.event
+    def waiting():
+      print("Waiting")
 
   def ConnectToServer(self, ipAddress='127.0.0.1', port=5000):
     self.sio.connect('http://' + ipAddress + ':' + str(port))
@@ -77,6 +81,10 @@ class Player:
   def SendGameData(self, GameState):
     print("SendGameData")
     self.sio.emit('game_data', GameState)
+
+  def SignalVictory(self):
+    print("Game over")
+    self.sio.emit('gameover')
 
 if __name__ == "__main__":
 

--- a/src/server.py
+++ b/src/server.py
@@ -144,6 +144,15 @@ class CommunicationServer():  # External
       else:
         self.sio.emit('game_data', str(-1), to=sid) # error code response
 
+    @self.sio.event
+    def gameover(sid):
+      if game := self.FindActiveGameBySid(sid):
+        game.ConcludeGame(sid)
+        self.sio.emit('waiting', game.PlayerA)
+        self.sio.emit('waiting', game.PlayerB)
+      else:
+        print(f'ERROR: Event sent by inactive player `{sid}`.')
+
   def FindActiveGameBySid(self, sid: str) -> Optional[TypeVar("Game")]:
     for game in self.ActiveGames:
       if (sid == game.PlayerA.get_id() or sid == game.PlayerB.get_id()) and game.Active: # the player 'sid' is playing in the game and the game is still going on
@@ -229,7 +238,7 @@ class PlayerInfo:
     ### TODO: init `GamesLeft`
     self.GamesLeft = 0
     self.NumberOfWins = 0
-      
+
   def lose(self):
     self.GamesPlayed += 1
     self.GamesLeft -= 1


### PR DESCRIPTION
`socketio` event in `CommunicationServer`

- `on_gameover` (internal)
  - should be decorated with `socketio.on('gameover')`, the event should be signaled by the winning client. The method concludes the game, adds a point to the winning player and emits the event `waiting` to both players.
  - arguments:
    - `sid`

method in `Player`:

- `SignalVictory`
  - Signals the server that you've won the current game

- `on_wait` (internal)
  - should be decorated with `socketio.on('waiting')`, acts as a signal for the player that the server is waiting for the next round. Doesn't have to do anything before integration with game platform

